### PR TITLE
Add validation to group name.

### DIFF
--- a/app/controllers/application_settings/group_managements_controller.rb
+++ b/app/controllers/application_settings/group_managements_controller.rb
@@ -20,6 +20,8 @@ class ApplicationSettings::GroupManagementsController < ApplicationController
   end
 
   def create
+    @groups = Group.all
+
     @group = Group.new(group_params)
 
     respond_to do |format|
@@ -27,7 +29,7 @@ class ApplicationSettings::GroupManagementsController < ApplicationController
         format.html { redirect_to application_settings_group_managements_path, notice: 'Group was successfully created.' }
         format.json { render :show, status: :ok, location: @group }
       else
-        format.html { render :edit }
+        format.html { render :index }
         format.json { render json: @group.errors, status: :unprocessable_entity }
       end
     end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -15,6 +15,8 @@ class Group < ApplicationRecord
   has_many :group_projects, dependent: :destroy
   has_many :projects, through: :group_projects
 
+  validates :name, presence: true
+
   accepts_nested_attributes_for :group_users
 
   def group_image_url

--- a/app/views/application_settings/group_managements/index.html.erb
+++ b/app/views/application_settings/group_managements/index.html.erb
@@ -13,7 +13,7 @@
             <%= simple_form_for @group, url: application_settings_group_managements_path do |f| %>
               <% if @group.errors.any? %>
                 <div id="error_explanation">
-                  <h2><%= t('errors.messages.not_saved.other', count: group.errors.count, resource: 'Group') %></h2>
+                  <h2><%= t('errors.messages.not_saved.other', count: @group.errors.count, resource: 'Group') %></h2>
 
                   <ul>
                     <% @group.errors.full_messages.each do |message| %>


### PR DESCRIPTION
I found an issue where adding a group without a name made it impossible to open '/ application_settings/user_managements'.

So I am fixing the following 4 points.

1. Group name is required
2. Change the rendering destination at validation error from edit to index
3. Set @groups when creating
4. Change 'group' in index.html.erb to '@group'