### PR TITLE
Check the existence of the user to be added to the group.

### DIFF
--- a/app/controllers/application_settings/group_managements_controller.rb
+++ b/app/controllers/application_settings/group_managements_controller.rb
@@ -46,11 +46,17 @@ class ApplicationSettings::GroupManagementsController < ApplicationController
   end
 
   def add_user
-    @group.users << User.find(group_params[:user_id])
+    user = User.find_by(id: group_params[:user_id])
+    if user.present?
+      @group.users << user
 
-    respond_to do |format|
-      format.html { redirect_to application_settings_group_management_path(@group), notice: 'Group was successfully updated.' }
-      format.json { render :show, status: :ok, location: @group }
+      respond_to do |format|
+        format.html { redirect_to application_settings_group_management_path(@group), notice: 'Group was successfully updated.' }
+        format.json { render :show, status: :ok, location: @group }
+      end
+    else
+      @addable_users = User.where.not(id: @group.users)
+      render :show
     end
   end
 


### PR DESCRIPTION
A check was added because a 404 error occurred when the user to add to the group was empty