### PR TITLE
Options are empty on reload.

### DIFF
--- a/app/javascript/pages/ProjectSettings/GroupManagementsPage.vue
+++ b/app/javascript/pages/ProjectSettings/GroupManagementsPage.vue
@@ -78,10 +78,7 @@ export default {
   },
   mounted() {
     this.projectId = this.$route.meta.projectId
-
-    this.getGroups({
-      projectId: this.projectId
-    })
+    this.getGroupsByName('').then(groups => { this.matchedGroups = groups })
   },
   computed: {
     ...mapState('GroupManagements', {
@@ -112,7 +109,6 @@ export default {
       })
     },
     ...mapActions('GroupManagements', {
-      getGroups: 'getGroups',
       addGroup: 'addGroup',
       deleteGroup: 'deleteGroup',
       getGroupsByName: 'getGroupsByName'


### PR DESCRIPTION
reload時にoptionsが空となっていました。
リロード時に `getGroupsByName('')` をすることでoptionsを設定します。