### PR TITLE
Fix missing before_action callbacks and i18n hardcoded Japanese text

### DIFF
--- a/app/controllers/application_settings/group_managements_controller.rb
+++ b/app/controllers/application_settings/group_managements_controller.rb
@@ -2,7 +2,7 @@ class ApplicationSettings::GroupManagementsController < ApplicationController
   authorize_resource class: false
 
   before_action :set_group, only: [
-    :show, :edit, :update, :destroy, :add_user, :remove_user
+    :show, :update, :destroy, :add_user, :remove_user
   ]
 
   GROUP_PER_PAGE = 25

--- a/app/controllers/application_settings/user_managements_controller.rb
+++ b/app/controllers/application_settings/user_managements_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationSettings::UserManagementsController < ApplicationController
   authorize_resource class: false
   before_action :set_user, only: [
-    :show, :update, :edit, :destroy,
+    :update, :edit, :destroy,
     :update_role, :destroy_image
   ]
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -10,15 +10,15 @@
         <%= f.hidden_field :reset_password_token %>
 
         <div class="space-y-2">
-          <% min_len = @minimum_password_length ? " (#{@minimum_password_length}文字以上)" : '' %>
+          <% min_len = @minimum_password_length ? " #{t('devise.shared.minimum_password_length', count: @minimum_password_length, default: "(#{@minimum_password_length} characters minimum)")}" : '' %>
           <%= f.label :password, "#{t('.new_password', default: 'New password')}#{min_len}", class: 'text-sm font-medium' %>
-          <%= f.password_field :password, autofocus: true, autocomplete: 'new-password', placeholder: '••••••••',
+          <%= f.password_field :password, autofocus: true, autocomplete: 'new-password', placeholder: t('.password_placeholder', default: 'Enter new password'),
                 class: 'h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring' %>
         </div>
 
         <div class="space-y-2">
           <%= f.label :password_confirmation, t('.confirm_new_password', default: 'Confirm new password'), class: 'text-sm font-medium' %>
-          <%= f.password_field :password_confirmation, autocomplete: 'new-password', placeholder: '••••••••',
+          <%= f.password_field :password_confirmation, autocomplete: 'new-password', placeholder: t('.password_confirmation_placeholder', default: 'Re-enter new password'),
                 class: 'h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring' %>
         </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -29,21 +29,21 @@
       </div>
 
       <div class="space-y-2">
-        <% min_len = @minimum_password_length ? " (#{@minimum_password_length}文字以上)" : '' %>
+        <% min_len = @minimum_password_length ? " #{t('devise.shared.minimum_password_length', count: @minimum_password_length, default: "(#{@minimum_password_length} characters minimum)")}" : '' %>
         <%= f.label :password, "#{t('activerecord.attributes.user.password', default: 'Password')}#{min_len} — #{t('.leave_blank_if_you_don_t_want_to_change_it')}", class: 'text-sm font-medium' %>
-        <%= f.password_field :password, autocomplete: 'off', placeholder: '••••••••',
+        <%= f.password_field :password, autocomplete: 'off', placeholder: t('.password_placeholder', default: 'Enter new password'),
               class: 'h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring' %>
       </div>
 
       <div class="space-y-2">
         <%= f.label :password_confirmation, class: 'text-sm font-medium' %>
-        <%= f.password_field :password_confirmation, autocomplete: 'off', placeholder: '••••••••',
+        <%= f.password_field :password_confirmation, autocomplete: 'off', placeholder: t('.password_confirmation_placeholder', default: 'Re-enter new password'),
               class: 'h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring' %>
       </div>
 
       <div class="space-y-2">
         <%= f.label :current_password, "#{t('activerecord.attributes.user.current_password', default: 'Current password')} — #{t('.we_need_your_current_password_to_confirm_your_changes')}", class: 'text-sm font-medium' %>
-        <%= f.password_field :current_password, autocomplete: 'off', placeholder: '••••••••',
+        <%= f.password_field :current_password, autocomplete: 'off', placeholder: t('.current_password_placeholder', default: 'Enter current password'),
               class: 'h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring' %>
       </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -34,7 +34,7 @@
         </div>
 
         <div class="space-y-2">
-          <% min_len = @minimum_password_length ? " (#{@minimum_password_length}文字以上)" : '' %>
+          <% min_len = @minimum_password_length ? " #{t('devise.shared.minimum_password_length', count: @minimum_password_length, default: "(#{@minimum_password_length} characters minimum)")}" : '' %>
           <%= f.label :password, "#{t('activerecord.attributes.user.password', default: 'Password')}#{min_len}", class: 'text-sm font-medium' %>
           <%= f.password_field :password, placeholder: t('.password_placeholder', default: 'Enter password'),
                 class: 'h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring' %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -45,7 +45,6 @@ en:
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
       updated: "Your account has been updated successfully."
       updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
-    registrations:
       new:
         have_account: "Already have an account?"
     sessions:
@@ -55,17 +54,18 @@ en:
       signed_in: "Signed in successfully."
       signed_out: "Signed out successfully."
       already_signed_out: "Signed out successfully."
+    shared:
+      minimum_password_length: "(%{count} characters minimum)"
+      links:
+        sign_in: "Sign in"
+        sign_up: "Sign up"
+        forgot_your_password: "Forgot your password?"
+        sign_in_with_provider: "Sign in with %{provider}"
+        sign_up_with_provider: "Sign up with %{provider}"
     unlocks:
       send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
       unlocked: "Your account has been unlocked successfully. Please sign in to continue."
-  shared:
-    links:
-      sign_in: "Sign in"
-      sign_up: "Sign up"
-      forgot_your_password: "Forgot your password?"
-      sign_in_with_provider: "Sign in with %{provider}"
-      sign_up_with_provider: "Sign up with %{provider}"
   errors:
     messages:
       already_confirmed: "was already confirmed, please try signing in"

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -82,6 +82,8 @@ ja:
         change_your_password: パスワードを変更
         confirm_new_password: 確認用新しいパスワード
         new_password: 新しいパスワード
+        password_placeholder: 新しいパスワードを入力
+        password_confirmation_placeholder: 新しいパスワードを再入力
       new:
         forgot_your_password: パスワードを忘れましたか?
         forgot_your_password_message: 登録に利用したメールアドレスを入力してください
@@ -103,6 +105,9 @@ ja:
         unhappy: 気に入りません
         update: 更新
         we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+        password_placeholder: 新しいパスワードを入力
+        password_confirmation_placeholder: 新しいパスワードを再入力
+        current_password_placeholder: 現在のパスワードを入力
       new:
         sign_up: 新規登録
         sign_up_with_app_name: "%{app_name} に新規登録"


### PR DESCRIPTION
- Remove :edit from group_managements before_action :only (action not implemented)
- Remove :show from user_managements before_action :only (action not implemented)
- Replace hardcoded Japanese "文字以上" with devise.shared.minimum_password_length i18n key in passwords/edit and registrations/edit
- Replace hardcoded "••••••••" placeholders with i18n keys in passwords/edit and registrations/edit
- Fix devise.en.yml structure: move shared.links inside devise scope, merge duplicate registrations key