### PR TITLE
fix: resolve Kanban drag flicker and expand isDirty guard in TicketModal

### DIFF
--- a/app/javascript/components/react/Kanban/index.tsx
+++ b/app/javascript/components/react/Kanban/index.tsx
@@ -117,10 +117,14 @@ function KanbanInner({
         row_order_position: data.newIndex,
       }),
     onMutate: () => setIsMutating(true),
-    onSettled: () => setIsMutating(false),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: ['kanban', projectId, sprintId] }),
-    onError: () => toast.error(t('message.failedToMoveTask')),
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ['kanban', projectId, sprintId] });
+      setIsMutating(false);
+    },
+    onError: () => {
+      setIsMutating(false);
+      toast.error(t('message.failedToMoveTask'));
+    },
   });
 
   useEffect(() => {

--- a/app/javascript/components/react/shared/TicketModal.tsx
+++ b/app/javascript/components/react/shared/TicketModal.tsx
@@ -123,7 +123,15 @@ export default function TicketModal({
   const isDirty =
     isEdit &&
     (() => {
-      if (isNew) return form.title.trim() !== '' || form.body.trim() !== '';
+      if (isNew)
+        return (
+          form.title.trim() !== '' ||
+          form.body.trim() !== '' ||
+          tags.length > 0 ||
+          newCategoryId !== '' ||
+          newAssigneeId !== '' ||
+          newStatusId !== ''
+        );
       return (
         form.title !== (ticket?.title ?? '') ||
         form.body !== (ticket?.body ?? '')


### PR DESCRIPTION
- Await invalidateQueries in onSuccess before clearing isMutating, preventing localStories from syncing with stale server data mid-refetch
- Extend isDirty check for new tickets to include tags, category, assignee, and status fields