### PR TITLE
fix: prevent Kanban flicker from concurrent mutations and duplicate broadcasts

### DIFF
--- a/app/javascript/hooks/useProjectChannel.ts
+++ b/app/javascript/hooks/useProjectChannel.ts
@@ -31,15 +31,20 @@ export function useProjectChannel(projectId: string) {
     useState<ConnectionStatus>('connecting');
 
   // Debounce timers per query key prefix to collapse rapid successive invalidations
-  const debounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const debounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
 
   const debounceInvalidate = useCallback((key: string, fn: () => void) => {
     const existing = debounceTimers.current.get(key);
     if (existing) clearTimeout(existing);
-    debounceTimers.current.set(key, setTimeout(() => {
-      debounceTimers.current.delete(key);
-      fn();
-    }, 300));
+    debounceTimers.current.set(
+      key,
+      setTimeout(() => {
+        debounceTimers.current.delete(key);
+        fn();
+      }, 300),
+    );
   }, []);
 
   useEffect(() => {
@@ -97,7 +102,7 @@ export function useProjectChannel(projectId: string) {
 
     return () => {
       subscriptionRef.current?.unsubscribe();
-      debounceTimers.current.forEach((t) => clearTimeout(t));
+      for (const t of debounceTimers.current.values()) clearTimeout(t);
       debounceTimers.current.clear();
     };
   }, [projectId, qc, debounceInvalidate]);

--- a/app/javascript/hooks/useProjectChannel.ts
+++ b/app/javascript/hooks/useProjectChannel.ts
@@ -1,6 +1,6 @@
 import { createConsumer } from '@rails/actioncable';
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 const consumer = createConsumer();
 
@@ -30,6 +30,18 @@ export function useProjectChannel(projectId: string) {
   const [connectionStatus, setConnectionStatus] =
     useState<ConnectionStatus>('connecting');
 
+  // Debounce timers per query key prefix to collapse rapid successive invalidations
+  const debounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const debounceInvalidate = useCallback((key: string, fn: () => void) => {
+    const existing = debounceTimers.current.get(key);
+    if (existing) clearTimeout(existing);
+    debounceTimers.current.set(key, setTimeout(() => {
+      debounceTimers.current.delete(key);
+      fn();
+    }, 300));
+  }, []);
+
   useEffect(() => {
     setConnectionStatus('connecting');
     subscriptionRef.current = consumer.subscriptions.create(
@@ -48,21 +60,35 @@ export function useProjectChannel(projectId: string) {
           setLastReceivedAt(new Date());
           switch (data.event) {
             case 'sprint_updated':
-              qc.invalidateQueries({ queryKey: ['sprints', projectId] });
-              qc.invalidateQueries({ queryKey: ['kanban', projectId] });
+              debounceInvalidate(`sprints-${projectId}`, () =>
+                qc.invalidateQueries({ queryKey: ['sprints', projectId] }),
+              );
+              debounceInvalidate(`kanban-${projectId}`, () =>
+                qc.invalidateQueries({ queryKey: ['kanban', projectId] }),
+              );
               break;
             case 'task_updated':
-              qc.invalidateQueries({ queryKey: ['kanban', projectId] });
-              qc.invalidateQueries({ queryKey: ['sprints', projectId] });
+              debounceInvalidate(`kanban-${projectId}`, () =>
+                qc.invalidateQueries({ queryKey: ['kanban', projectId] }),
+              );
+              debounceInvalidate(`sprints-${projectId}`, () =>
+                qc.invalidateQueries({ queryKey: ['sprints', projectId] }),
+              );
               break;
             case 'comment_updated':
-              qc.invalidateQueries({
-                queryKey: [data.ticket_type, data.ticket_id, projectId],
-              });
+              debounceInvalidate(`${data.ticket_type}-${data.ticket_id}`, () =>
+                qc.invalidateQueries({
+                  queryKey: [data.ticket_type, data.ticket_id, projectId],
+                }),
+              );
               break;
             case 'ticket_updated':
-              qc.invalidateQueries({ queryKey: ['sprints', projectId] });
-              qc.invalidateQueries({ queryKey: ['kanban', projectId] });
+              debounceInvalidate(`sprints-${projectId}`, () =>
+                qc.invalidateQueries({ queryKey: ['sprints', projectId] }),
+              );
+              debounceInvalidate(`kanban-${projectId}`, () =>
+                qc.invalidateQueries({ queryKey: ['kanban', projectId] }),
+              );
               break;
           }
         },
@@ -71,8 +97,10 @@ export function useProjectChannel(projectId: string) {
 
     return () => {
       subscriptionRef.current?.unsubscribe();
+      debounceTimers.current.forEach((t) => clearTimeout(t));
+      debounceTimers.current.clear();
     };
-  }, [projectId, qc]);
+  }, [projectId, qc, debounceInvalidate]);
 
   return { lastReceivedAt, connectionStatus };
 }

--- a/app/models/concerns/broadcastable.rb
+++ b/app/models/concerns/broadcastable.rb
@@ -11,7 +11,14 @@ module Broadcastable
     project_id = resolve_project_id
     return unless project_id
 
-    ActionCable.server.broadcast("project_#{project_id}", build_payload(project_id))
+    payload = build_payload(project_id)
+    key = payload.values.join('-')
+
+    Current.broadcast_events_sent ||= Set.new
+    return if Current.broadcast_events_sent.include?(key)
+    Current.broadcast_events_sent.add(key)
+
+    ActionCable.server.broadcast("project_#{project_id}", payload)
   end
 
   def resolve_project_id

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,3 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :broadcast_events_sent
+end

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
   },
   "version": "4.3.2",
   "scripts": {
-    "lint": "biome check app/javascript/entrypoints app/javascript/components app/javascript/lib",
-    "lint:fix": "biome check --write app/javascript/entrypoints app/javascript/components app/javascript/lib",
-    "format": "biome format --write app/javascript/entrypoints app/javascript/components app/javascript/lib"
+    "lint": "biome check app/javascript",
+    "lint:fix": "biome check --write app/javascript",
+    "format": "biome format --write app/javascript"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.8",


### PR DESCRIPTION
- Replace boolean isMutating with a ref counter so the localStories guard stays active until all in-flight drag mutations have settled
- Deduplicate ActionCable broadcasts per request via CurrentAttributes, preventing ranked-model from firing one broadcast per reordered row
- Debounce invalidateQueries in useProjectChannel (300ms per query key) to collapse rapid successive notifications into a single refetch